### PR TITLE
Corrected issue with custom joinOn clause

### DIFF
--- a/src/Storage/Database/Engine/Driver/Language/SQL/Join.php
+++ b/src/Storage/Database/Engine/Driver/Language/SQL/Join.php
@@ -68,12 +68,14 @@ class Join implements AccessorInterface
 		$stringParts = Util::split($customString, '=');
 
 		$firstParts = Util::split(array_shift($stringParts), '.');
-		$onCollection = Util::quote($firstParts[0]);
-		$onCollectionWithValue = Util::quoteAndJoin($firstParts, '.');
+		$secondParts = Util::split(array_shift($stringParts), '.');
 
-		$collectionWithValue = Util::splitThenQuoteAndJoin(array_shift($stringParts), '.');
+		$onCollection = Util::quote($secondParts[0]);
+		$onCollectionWithValue = Util::quoteAndJoin($secondParts, '.');
 
-		$joinString = $this->joinString($join->value, $onCollection, $collectionWithValue, $onCollectionWithValue);
+		$currentCollectionWithValue = Util::quoteAndJoin($firstParts, '.');
+
+		$joinString = $this->joinString($join->value, $onCollection, $currentCollectionWithValue, $onCollectionWithValue);
 
 		return $joinString;
 	}

--- a/tests/unit/Storage/Database/Engine/Driver/Language/SQL/JoinTest.php
+++ b/tests/unit/Storage/Database/Engine/Driver/Language/SQL/JoinTest.php
@@ -28,14 +28,14 @@ class JoinTest extends TestCase
 			],
 			3 => [
 				[
-					['Log.UserID = User.UserID', QueryJoin::STRAIGHT, null],
+					['User.UserID = Log.UserID', QueryJoin::STRAIGHT, null],
 				],
 				'STRAIGHT JOIN `Log` ON `User`.`UserID` = `Log`.`UserID`'
 			],
 			4 => [
 				[
 					['User.UserID', QueryJoin::LEFT, 'UserRole.UserID'],
-					['UserAccess.UserRoleID = UserRole.UserRoleID', QueryJoin::LEFT, null]
+					['UserRole.UserRoleID = UserAccess.UserRoleID', QueryJoin::LEFT, null]
 				],
 				'LEFT JOIN `UserRole` ON `User`.`UserID` = `UserRole`.`UserID`' .
 				' LEFT JOIN `UserAccess` ON `UserRole`.`UserRoleID` = `UserAccess`.`UserRoleID`'

--- a/tests/unit/Storage/Database/Engine/Driver/Language/SQL/Query/DeleteTest.php
+++ b/tests/unit/Storage/Database/Engine/Driver/Language/SQL/Query/DeleteTest.php
@@ -22,7 +22,7 @@ class DeleteTest extends TestCase
 			[
 				new QueryObject(
 					collections: ['User'],
-					joins: [['UserRole.UserID = User.UserID', Join::INNER, null]],
+					joins: [['User.UserID = UserRole.UserID', Join::INNER, null]],
 					filters: [
 						[
 							Filter::buildGroup(['UserRole.Role' => 'leader']),

--- a/tests/unit/Storage/Database/Engine/Driver/Language/SQL/Query/UpdateTest.php
+++ b/tests/unit/Storage/Database/Engine/Driver/Language/SQL/Query/UpdateTest.php
@@ -22,7 +22,7 @@ class UpdateTest extends TestCase
 				new QueryObject(
 					collections: ['User'],
 					fieldsWithValues: [['Name' => 'John']],
-					joins: [['UserRole.UserID = User.UserID', Join::INNER, null]],
+					joins: [['User.UserID = UserRole.UserID', Join::INNER, null]],
 					filters: [
 						[
 							Filter::buildGroup(['UserRole.Role' => 'leader']),


### PR DESCRIPTION
Resolves #34 

Changed how the custom joinOn clause emphasizes, to what comes after the ON-part of a join statement. 
Rather than thinking "new collection first". I believe this was an oversight while creating the feature.

The bug "never" really existed, the code was expecting the clause to be written "the other way around".
Which was not really what the user would expected it to be.

Previously
````
DB::query('User')
    ->joinOn('User.UserID', Join::INNER, 'UserRole.UserID')
    ->joinOn('Role.RoleID = UserRole.RoleID', Join::INNER)
    ->select('User.UserID', 'User.Username', 'Role.RoleID', 'Role.Role');
````  

After correction
````
DB::query('User')
    ->joinOn('User.UserID', Join::INNER, 'UserRole.UserID')
    ->joinOn('UserRole.RoleID = Role.RoleID', Join::INNER) 
    ->select('User.UserID', 'User.Username', 'Role.RoleID', 'Role.Role');
````  

Both of the above queries produces the same results.
The latter is however, easier to understand and more intuitive to use. 
