### PR TITLE
Dev

### DIFF
--- a/src/Storage/SQL/Component/Limit.php
+++ b/src/Storage/SQL/Component/Limit.php
@@ -8,14 +8,14 @@ use Projom\Storage\SQL\ComponentInterface;
 
 class Limit implements ComponentInterface
 {
-	private readonly int|string $limit;
+	private readonly null|int $limit;
 
-	public function __construct(int|string $limit)
+	public function __construct(null|int $limit)
 	{
 		$this->limit = $limit;
 	}
 
-	public static function create(int|string $limit): Limit
+	public static function create(null|int $limit): Limit
 	{
 		return new Limit($limit);
 	}
@@ -27,6 +27,6 @@ class Limit implements ComponentInterface
 
 	public function empty(): bool
 	{
-		return empty($this->limit);
+		return $this->limit === null;
 	}
 }

--- a/src/Storage/SQL/QueryBuilder.php
+++ b/src/Storage/SQL/QueryBuilder.php
@@ -22,7 +22,7 @@ class QueryBuilder
     private array $sorts = [];
     private array $joins = [];
     private array $groups = [];
-    private int|string $limit = '';
+    private null|int $limit = null;
     private array $formatting = [];
 
     private const DEFAULT_SELECT = '*';
@@ -302,7 +302,7 @@ class QueryBuilder
      * * Example use: $database->query('CollectionName')->limit(10)
      * * Example use: $database->query('CollectionName')->limit('10')
      */
-    public function limit(int|string $limit): QueryBuilder
+    public function limit(int $limit): QueryBuilder
     {
         $this->limit = $limit;
         return $this;

--- a/src/Storage/SQL/QueryObject.php
+++ b/src/Storage/SQL/QueryObject.php
@@ -17,7 +17,7 @@ class QueryObject
 		public array $filters = [],
 		public array $sorts = [],
 		public array $groups = [],
-		public int|string $limit = '',
+		public null|int $limit = null,
 		public array $formatting = [],
 	) {}
 }

--- a/tests/Unit/Storage/SQL/Component/LimitTest.php
+++ b/tests/Unit/Storage/SQL/Component/LimitTest.php
@@ -19,21 +19,9 @@ class LimitTest extends TestCase
 		$this->assertFalse($limit->empty());
 	}
 
-	public function test_create_string()
-	{
-		$limits = '10';
-		$limit = Limit::create($limits);
-
-		$this->assertEquals($limits, "$limit");
-		$this->assertFalse($limit->empty());
-	}
-
 	public function test_create_empty()
 	{
 		$limit = Limit::create(0);
-		$this->assertTrue($limit->empty());
-
-		$limit = Limit::create('');
-		$this->assertTrue($limit->empty());
+		$this->assertFalse($limit->empty());
 	}
 }


### PR DESCRIPTION
Refactored the typing of query builder `->limit(string|int $limit)` method.

Earlier any string could be sent in and used. 

The method `->imit(int $limit)` now forces an integer to be used.